### PR TITLE
Fixes for Windows users

### DIFF
--- a/line.py
+++ b/line.py
@@ -57,7 +57,10 @@ class Line:
 
   def create_icon(self):
     """Create the color icon using ImageMagick convert"""
-    script = "%s -units PixelsPerCentimeter -type TrueColorMatte -channel RGBA -size 16x16 -alpha transparent xc: -fill '#%s' -draw 'circle 7,7 8,10' png32:\"%s\"" % (self.settings.get("convert_path"), self.color(), self.icon_path())
+    script = "%s -units PixelsPerCentimeter -type TrueColorMatte -channel RGBA " \
+      "-size 16x16 -alpha transparent xc:none " \
+      "-fill \"#%s\" -draw \"circle 7,7 8,10\" png32:\"%s\"" % \
+      (self.settings.get("convert_path"), self.color(), self.icon_path())
     if not isfile(self.icon_path()):
         pr = subprocess.Popen(script,
           shell = True,


### PR DESCRIPTION
Commits:
- **Run script using subprocess instead of system to avoid flashing command line windows**
  Command line windows flashed while generating icons.
- **Fix script command line to work in Windows**
  ImageMagick call didn't work at all in Windows.
- **Fix color parsing: short format #xyz equals #xxyyzz, not #xyzxyz**
