### PR TITLE
Updated Reade to remove trailing item and link to ImageMagick

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,15 @@ Gutter Color is a Sublime Text plugin which displays a colored icon for all line
 
 ## Requirements
 
-* ImageMagick
+* [ImageMagick](http://www.imagemagick.org/)
 
 ## Configure
 
 * Install ImageMagick
 * Set the `convert_path` in `Preferences: GutterColor Settings – User` to the location of the ImageMagick `convert` script.
 
-
 ## TODO
 
 * Add support for SASS/LESS variables
 * Backport to ST2
 * Handle conflicts with GitGutter/VCS Gutter
-* 


### PR DESCRIPTION
The README has a trailing list item. I've also included a link to ImageMagick.
