### PR TITLE
Auto convert

### DIFF
--- a/line.py
+++ b/line.py
@@ -75,7 +75,8 @@ class Line:
 
   def create_icon(self):
     paths = [
-      "/usr/bin/convert"
+      "/usr/bin/convert",
+      "/usr/local/bin"
     ]
 
     paths.extend(glob.glob('/usr/local/Cellar/imagemagick/*/bin'))


### PR DESCRIPTION
Automatically find the `convert` method. Untested on Windows, but nobody has pointed out that it's not working? Since it appends the `convert` path from the settings file, it should still find it.
