### PR TITLE
Improve HEX_REGEXP

### DIFF
--- a/line.py
+++ b/line.py
@@ -17,7 +17,7 @@ class Line:
   # and then a comma and then the fourth digit.
   FOUR_DIGITS = '(' + THREE_DIGITS + '),' + DIGIT
 
-  HEX_REGEXP = '#((?:[0-9a-fA-F]{3}){1,2})'
+  HEX_REGEXP = '#((?:[0-9a-fA-F]{3}){1,2}(?![0-9a-fA-F]+))'
   RGB_REGEXP = 'rgb\(' + THREE_DIGITS + '\)'
   RGBA_REGEXP = 'rgba\(' + FOUR_DIGITS + '\)'
   HSL_REGEXP = 'hsl\(' + THREE_DIGITS + '\)'


### PR DESCRIPTION
As Sublime syntax highlighter does, it matches the color only if there is 3 or 6 characters (after the #), and will not render a preview of the first 3 characters. Otherwise it may be confusing and beginners could be tempted to try 4 or 5 characters values.

![capture](https://f.cloud.github.com/assets/5932082/2441587/4d5e8124-ae16-11e3-93b4-bdc36cc8e90c.PNG)
