### PR TITLE
Add quotes around the convert_path executable

### DIFF
--- a/line.py
+++ b/line.py
@@ -102,7 +102,7 @@ class Line:
 
   def create_icon(self):
     """Create the color icon using ImageMagick convert"""
-    script = "%s -units PixelsPerCentimeter -type TrueColorMatte -channel RGBA " \
+    script = "\"%s\" -units PixelsPerCentimeter -type TrueColorMatte -channel RGBA " \
       "-size 32x32 -alpha transparent xc:none " \
       "-fill \"%s\" -draw \"circle 15,16 8,10\" png32:\"%s\"" % \
       (self.settings.get("convert_path"), self.color(), self.icon_path())


### PR DESCRIPTION
Currently, the script fails to execute in Windows when the path includes spaces (e.g. "C:\Program Files"). Adding quotes around the convert script path fixes that.
