### PR TITLE
Updates to work in CSS3 and XML

### DIFF
--- a/GutterColor.sublime-settings
+++ b/GutterColor.sublime-settings
@@ -12,6 +12,6 @@
   /*
    * The syntax for which to run GutterColor.
    */
-  "supported_syntax": ["css", "scss", "sass", "less", "stylus"]
+  "supported_syntax": ["css", "scss", "sass", "less", "stylus", "css3", "xml"]
 
 }


### PR DESCRIPTION
Many dev use this CSS3 package:  https://github.com/y0ssar1an/CSS3_Syntax

Unfortunately it changes the mode to css3 rather than just CSS. This fixes that.

And for XML - this plugin is great when you are editing .tmTheme (sublime theme files) because you can see the colours in the sidebar. 

![](http://wes.io/WQAt/content)
