### PR TITLE
Add user-defined regex option

### DIFF
--- a/GutterColor.sublime-settings
+++ b/GutterColor.sublime-settings
@@ -14,4 +14,24 @@
    */
   "supported_syntax": ["css", "scss", "sass", "less", "stylus", "css3", "xml"]
 
+  /*
+   * Additional user-defined color matches.
+   */
+/*
+  "custom_colors": [
+    {
+      // The rule to match
+      "regex": "(['\"])((?:[0-9a-fA-F]{3}){1,2}(?![0-9a-fA-F]+))\\1",
+      // The capture group to use; defaults to 0 (the whole expression)
+      "group_id": 2,
+      // Strings to be concatenated before sending to ImageMagic
+      "output_prefix": "#",
+      "output_suffix": ""
+    },{
+      "regex": "color=([0-9a-fA-F]{6})",
+      "group_id": 1,
+      "output_prefix": "#"
+    }]
+*/
+
 }

--- a/line.py
+++ b/line.py
@@ -32,7 +32,7 @@ class Line:
     """Returns True/False depending on whether the line has a color in it"""
     return True if self.color() else False
 
-  def color(self):
+def color(self):
     """Returns the color in the line, if any."""
     if self.hex_color():
       return self.hex_color()
@@ -42,7 +42,10 @@ class Line:
       return self.rgba_color()
     if self.hsl_color():
       return self.hsl_color()
-    return self.hsla_color()
+    if self.hsla_color():
+      return self.hsla_color()
+    if not self.settings.get("custom_colors") == None:
+      return self.custom_color()
 
   def hex_color(self):
     """Returns the color in the line, if any hex is found."""
@@ -73,6 +76,17 @@ class Line:
     matches = re.search(Line.HSLA_REGEXP, self.text)
     if matches:
       return 'hsl(' + matches.group(1) + ')'
+
+  def custom_color(self):
+    """Returns the color in the line, if any user-defined is found."""
+    user_colors = self.settings.get("custom_colors")
+    for user_color in user_colors:
+      matches = re.search(user_color["regex"], self.text)
+      group_id = user_color["group_id"] if "group_id" in user_color else 0
+      prefix = user_color["output_prefix"] if "output_prefix" in user_color else ""
+      suffix = user_color["output_suffix"] if "output_suffix" in user_color else ""
+      if matches:
+        return prefix+matches.group(group_id)+suffix
 
 
   def icon_path(self):


### PR DESCRIPTION
I wanted to use GutterColor in a few situations not included already (e.g. quoted hex strings without initial #), but I figured they weren't common enough to merit being a default search. So I implemented a `custom_colors` setting that takes an array of objects defining new regexes and trivial string modifications to allow everyone to define their own "nonstandard" searches without modifying the package core.

![custom_regex_settings](https://cloud.githubusercontent.com/assets/1791252/3773924/53690cf8-191c-11e4-98e9-3282f568820d.PNG)

![custom_regex](https://cloud.githubusercontent.com/assets/1791252/3773918/224d9fd0-191c-11e4-9afb-6aed81eba62a.PNG)
