### PR TITLE
Reinstate rgba & hsla capture group

### DIFF
--- a/line.py
+++ b/line.py
@@ -13,7 +13,7 @@ class Line:
 
   # Four digits is three digits (which we save for later),
   # and then a comma and then the fourth digit.
-  FOUR_DIGITS = THREE_DIGITS + ',' + DIGIT
+  FOUR_DIGITS = '(' + THREE_DIGITS + '),' + DIGIT
 
   HEX_REGEXP = '#((?:[0-9a-fA-F]{3}){1,2}(?![0-9a-fA-F]+))'
   RGB_REGEXP = 'rgb\(' + THREE_DIGITS + '\)'


### PR DESCRIPTION
Reverts previous change that deleted the 3 digit capture group for RGBA and HSLA (which were breaking and getting errors). Addresses part of #53.
