### PR TITLE
Check if paths may already include executable

### DIFF
--- a/line.py
+++ b/line.py
@@ -132,10 +132,11 @@ class Line:
 
     convert_path = None
     for path in paths:
-      if os.path.isfile(os.path.join(path,convert_name)) and os.access(os.path.join(path,convert_name), os.X_OK):
-        convert_path = os.path.join(path,convert_name)
+      if not path.endswith(convert_name):
+        path = os.path.join(path,convert_name)
+      if os.path.isfile(path) and os.access(path, os.X_OK):
+        convert_path = path
         break
-
 
     """Create the color icon using ImageMagick convert"""
     script = "\"%s\" -units PixelsPerCentimeter -type TrueColorMatte -channel RGBA " \


### PR DESCRIPTION
The current convert-path-finding logic blindly appends the `convert_name` (the name of the executable) to the end of every path before checking it, but we give some examples where it is already on the end, and many users may logically think this is valid because the setting name `convert_path` is ambiguous (it's not `convert_directory`).

This change suppresses concatenation for path strings that already end with the executable name.
