### PR TITLE
fix windows convert.exe and PEP8 linter

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,13 +1,9 @@
 [
     {
-        "caption": "Preferences",
-        "mnemonic": "n",
         "id": "preferences",
         "children":
         [
             {
-                "caption": "Package Settings",
-                "mnemonic": "P",
                 "id": "package-settings",
                 "children":
                 [

--- a/file.py
+++ b/file.py
@@ -1,33 +1,31 @@
 from sublime import Region
-from threading import Thread
 from .line import Line
 
+
 class File():
-  """ A File corresponds to one sublime.View """
 
-  def __init__(self, view, action = 'initialize'):
-    self.view = view # sublime.View
-    self.id   = self.view.buffer_id()
-    self.action = action
-    self.scan()
+    """A File corresponds to one sublime.View."""
 
-  def scan(self):
-    """Scan the file for colours and add/remove regions appropriately"""
+    def __init__(self, view, action='initialize'):
+        self.view = view  # sublime.View
+        self.id = self.view.buffer_id()
+        self.action = action
+        self.scan()
 
-    # Return a list of all the line regions in the current file
-    if self.action == 'update':
-      regions = [self.view.line(s) for s in self.view.sel()]
-    else:
-      regions = self.view.lines(Region(0, self.view.size()))
+    def scan(self):
+        """Scan the file for colours and add/remove regions appropriately."""
+        # Return a list of all the line regions in the current file
+        if self.action == 'update':
+            regions = [self.view.line(s) for s in self.view.sel()]
+        else:
+            regions = self.view.lines(Region(0, self.view.size()))
 
-    for region in regions:
-      line = Line(self.view, region, self.id)
-      if line.has_color():
-        line.add_region()
-      else:
-        try:
-          self.view.erase_regions("gutter_color_%s" % region.a)
-        except:
-          pass
-
-
+        for region in regions:
+            line = Line(self.view, region, self.id)
+            if line.has_color():
+                line.add_region()
+            else:
+                try:
+                    self.view.erase_regions("gutter_color_%s" % region.a)
+                except:
+                    pass

--- a/gutter_color.py
+++ b/gutter_color.py
@@ -2,164 +2,189 @@ from .file import File
 from sublime_plugin import EventListener, WindowCommand, TextCommand
 from sublime import load_settings, save_settings, load_resource, packages_path
 
-def clear_cache(force = False):
-  """
-  If the folder exists, and has more than 5MB of icons in the cache, delete
-  it to clear all the icons then recreate it.
-  """
-  from os.path import getsize, join, isfile, exists
-  from os import makedirs, listdir
-  from sublime import cache_path
-  from shutil import rmtree
 
-  # The icon cache path
-  icon_path = join(cache_path(), "GutterColor")
+def clear_cache(force=False):
+    """
+    If the folder exists, and has more than 5MB of icons in the cache, delete
+    it to clear all the icons then recreate it.
+    """
+    from os.path import getsize, join, isfile, exists
+    from os import makedirs, listdir
+    from sublime import cache_path
+    from shutil import rmtree
 
-  # The maximum amount of space to take up
-  limit = 5242880 # 5 MB
+    # The icon cache path
+    icon_path = join(cache_path(), "GutterColor")
 
-  if exists(icon_path):
-    size = sum(getsize(join(icon_path, f)) for f in listdir(icon_path) if isfile(join(icon_path, f)))
-    if force or (size > limit): rmtree(icon_path)
+    # The maximum amount of space to take up
+    limit = 5242880  # 5 MB
 
-  if not exists(icon_path): makedirs(icon_path)
+    if exists(icon_path):
+        size = sum(getsize(join(icon_path, f))
+                   for f in listdir(icon_path) if isfile(join(icon_path, f)))
+        if force or (size > limit):
+            rmtree(icon_path)
+
+    if not exists(icon_path):
+        makedirs(icon_path)
+
 
 def plugin_loaded():
-  clear_cache()
-  fix_schemes_in_windows()
+    clear_cache()
+    fix_schemes_in_windows()
+
 
 class GutterColorClearCacheCommand(WindowCommand):
-  def run(self):
-    clear_cache(True)
+
+    def run(self):
+        clear_cache(True)
+
 
 class GutterColorEventListener(EventListener):
-  """Scan the view when it gains focus, and when it is saved."""
 
-  def on_activated_async(self, view):
-    """Scan file when it gets focus"""
-    if syntax(view) in settings().get('supported_syntax'):
-      fix_scheme_in_view(view)
-      File(view)
+    """Scan the view when it gains focus, and when it is saved."""
 
-  def on_modified(self, view):
-    """Scan file when it is modified"""
-    if syntax(view) in settings().get('supported_syntax'):
-      File(view, 'update')
+    def on_activated_async(self, view):
+        """Scan file when it gets focus."""
+        if syntax(view) in settings().get('supported_syntax'):
+            fix_scheme_in_view(view)
+            File(view)
 
-  def on_pre_save_async(self, view):
-    """Scan file before it is saved"""
-    if syntax(view) in settings().get('supported_syntax'):
-      File(view, 'update')
+    def on_modified(self, view):
+        """Scan file when it is modified."""
+        if syntax(view) in settings().get('supported_syntax'):
+            File(view, 'update')
+
+    def on_pre_save_async(self, view):
+        """Scan file before it is saved."""
+        if syntax(view) in settings().get('supported_syntax'):
+            File(view, 'update')
+
 
 def settings():
-  """Shortcut to the settings"""
-  return load_settings("GutterColor.sublime-settings")
+    """Shortcut to the settings."""
+    return load_settings("GutterColor.sublime-settings")
+
 
 def syntax(view):
-  """Return the view syntax"""
-  syntax = view.settings().get('syntax')
-  return syntax.split('/')[-1].split('.')[0].lower() if syntax is not None else "plain text"
+    """Return the view syntax."""
+    syntax = view.settings().get('syntax')
+    return syntax.split('/')[-1].split('.')[0].lower() if syntax is not None else "plain text"
+
 
 def current_directory(full=False):
-  """Return the name of the directory containing this plugin"""
-  from os.path import dirname, realpath, split
-  if full:
-    return dirname(realpath(__file__))
-  else:
-    return split(dirname(realpath(__file__)))[1]
+    """Return the name of the directory containing this plugin."""
+    from os.path import dirname, realpath, split
+    if full:
+        return dirname(realpath(__file__))
+    else:
+        return split(dirname(realpath(__file__)))[1]
+
 
 def fix_schemes_in_windows():
-  """Change color schemes for all current views in the supported syntax list"""
-  from sublime import windows
-  for window in windows():
-    for view in window.views():
-      if syntax(view) in settings().get('supported_syntax'):
-        fix_scheme_in_view(view)
+    """Change color schemes for all current views in the supported syntax list"""
+    from sublime import windows
+    for window in windows():
+        for view in window.views():
+            if syntax(view) in settings().get('supported_syntax'):
+                fix_scheme_in_view(view)
+
 
 def fix_scheme_in_view(view, regenerate=False, ignore_flags=False):
-  """Change color scheme in settings relevant to current view"""
-  fix_flag = settings().get("fix_color_schemes", False)
-  (fix_syntax, fix_global, fix_custom) = (False, False, False)
-  custom_files = []
-  if fix_flag == True:
-    (fix_syntax, fix_global) = (True, True)
-  elif isinstance(fix_flag, list):
-    for label in fix_flag:
-      if label in ("syntax", "syntax-specific"):
-        fix_syntax = True
-      if label in ("user", "global", "preferences"):
-        fix_global = True
-      if ".sublime-settings" in label:
-        fix_custom = True
-        custom_files.append(label)
-  elif ignore_flags:
-    pass # otherwise we might quit when we want to force a check contrary to user prefs
-  else:
-    return # setting is false, nonexistant, or malformed, so exit
-
-  current_scheme = view.settings().get("color_scheme")
-  modified_marker = ".gcfix."
-  if modified_marker in current_scheme:
-    if regenerate:
-      new_scheme = current_scheme
+    """Change color scheme in settings relevant to current view."""
+    fix_flag = settings().get("fix_color_schemes", False)
+    (fix_syntax, fix_global, fix_custom) = (False, False, False)
+    custom_files = []
+    if fix_flag == True:
+        (fix_syntax, fix_global) = (True, True)
+    elif isinstance(fix_flag, list):
+        for label in fix_flag:
+            if label in ("syntax", "syntax-specific"):
+                fix_syntax = True
+            if label in ("user", "global", "preferences"):
+                fix_global = True
+            if ".sublime-settings" in label:
+                fix_custom = True
+                custom_files.append(label)
+    elif ignore_flags:
+        # otherwise we might quit when we want to force a check contrary to
+        # user prefs
+        pass
     else:
-      return # this view already has a fixed scheme and we aren't regenerating, so exit
-  else:
-    new_scheme =  "Packages/"+current_directory()+"/"+current_scheme.split("/")[-1].split(".")[0]+\
-                  modified_marker + current_scheme.split(".")[-1]
+        return  # setting is false, nonexistant, or malformed, so exit
 
-  if fix_custom:
-    for custom_filename in custom_files:
-      if fix_scheme_in_settings(custom_filename, current_scheme, new_scheme):
-        return
-  if fix_syntax or ignore_flags:
-    syntax_filename = view.settings().get('syntax').split('/')[-1].split('.')[0] + ".sublime-settings"
-    if fix_scheme_in_settings(syntax_filename, current_scheme, new_scheme):
-      return
-  if fix_global or ignore_flags:
-    if fix_scheme_in_settings("Preferences.sublime-settings", current_scheme, new_scheme):
-      return
-  print("Could not find or access the settings file where current color_scheme ("+current_scheme+") is set.")
-
-
-def fix_scheme_in_settings(settings_file,current_scheme, new_scheme, regenerate=False):
-  """Change the color scheme in the given Settings to a background-corrected one"""
-  from os.path import join, normpath, isfile
-
-  settings = load_settings(settings_file)
-  settings_scheme = settings.get("color_scheme")
-  if current_scheme == settings_scheme:
-    new_scheme_path =  join(packages_path(), normpath(new_scheme[len("Packages/"):]))
-    if isfile(new_scheme_path) and not regenerate:
-      settings.set("color_scheme", new_scheme)
+    current_scheme = view.settings().get("color_scheme")
+    modified_marker = ".gcfix."
+    if modified_marker in current_scheme:
+        if regenerate:
+            new_scheme = current_scheme
+        else:
+            # this view already has a fixed scheme and we aren't regenerating,
+            # so exit
+            return
     else:
-      generate_scheme_fix(current_scheme, new_scheme_path)
-      settings.set("color_scheme", new_scheme)
-    save_settings(settings_file)
-    return True
-  return False
+        new_scheme =  "Packages/" + current_directory() + "/" + current_scheme.split("/")[-1].split(".")[0] +\
+                      modified_marker + current_scheme.split(".")[-1]
+
+    if fix_custom:
+        for custom_filename in custom_files:
+            if fix_scheme_in_settings(custom_filename, current_scheme, new_scheme):
+                return
+    if fix_syntax or ignore_flags:
+        syntax_filename = view.settings().get('syntax').split(
+            '/')[-1].split('.')[0] + ".sublime-settings"
+        if fix_scheme_in_settings(syntax_filename, current_scheme, new_scheme):
+            return
+    if fix_global or ignore_flags:
+        if fix_scheme_in_settings("Preferences.sublime-settings", current_scheme, new_scheme):
+            return
+    print("Could not find or access the settings file where current color_scheme (" +
+          current_scheme + ") is set.")
+
+
+def fix_scheme_in_settings(settings_file, current_scheme, new_scheme, regenerate=False):
+    """Change the color scheme in the given Settings to a background-corrected one"""
+    from os.path import join, normpath, isfile
+
+    settings = load_settings(settings_file)
+    settings_scheme = settings.get("color_scheme")
+    if current_scheme == settings_scheme:
+        new_scheme_path = join(
+            packages_path(), normpath(new_scheme[len("Packages/"):]))
+        if isfile(new_scheme_path) and not regenerate:
+            settings.set("color_scheme", new_scheme)
+        else:
+            generate_scheme_fix(current_scheme, new_scheme_path)
+            settings.set("color_scheme", new_scheme)
+        save_settings(settings_file)
+        return True
+    return False
+
 
 def generate_scheme_fix(old_scheme, new_scheme_path):
-  """Appends background-correction XML to a color scheme file"""
-  from os.path import join
-  from re import sub
-  UUID_REGEX = '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
+    """Appends background-correction XML to a color scheme file."""
+    from os.path import join
+    from re import sub
+    UUID_REGEX = '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
 
-  with open(join(packages_path(),current_directory(),'background_fix.xml')) as f:
-    xml = f.read()
-  scheme_data = load_resource(old_scheme) # only valid for ST3 API!
+    with open(join(packages_path(), current_directory(), 'background_fix.xml')) as f:
+        xml = f.read()
+    scheme_data = load_resource(old_scheme)  # only valid for ST3 API!
 
-  insertion_point = scheme_data.rfind("</array>")
-  new_scheme_data = scheme_data[:insertion_point] + xml + scheme_data[insertion_point:]
+    insertion_point = scheme_data.rfind("</array>")
+    new_scheme_data = scheme_data[
+        :insertion_point] + xml + scheme_data[insertion_point:]
 
-  def uuid_gen(args):
-    from uuid import uuid4
-    return str(uuid4())
-  new_scheme_data = sub(UUID_REGEX, uuid_gen, new_scheme_data)
+    def uuid_gen(args):
+        from uuid import uuid4
+        return str(uuid4())
+    new_scheme_data = sub(UUID_REGEX, uuid_gen, new_scheme_data)
 
-  with open(new_scheme_path, "wb") as f:
-    f.write(new_scheme_data.encode("utf-8"))
+    with open(new_scheme_path, "wb") as f:
+        f.write(new_scheme_data.encode("utf-8"))
+
 
 class GutterColorFixCurrentScheme(TextCommand):
-  def run(self, args):
-    fix_scheme_in_view(self.view, True, True)
+
+    def run(self, args):
+        fix_scheme_in_view(self.view, True, True)

--- a/gutter_color.py
+++ b/gutter_color.py
@@ -69,7 +69,8 @@ def settings():
 def syntax(view):
     """Return the view syntax."""
     syntax = view.settings().get('syntax')
-    return syntax.split('/')[-1].split('.')[0].lower() if syntax is not None else "plain text"
+    return syntax.split('/')[-1].split('.')[0].lower() if syntax is not None \
+        else "plain text"
 
 
 def current_directory(full=False):
@@ -82,7 +83,9 @@ def current_directory(full=False):
 
 
 def fix_schemes_in_windows():
-    """Change color schemes for all current views in the supported syntax list"""
+    """
+    Change color schemes for all current views in the supported syntax list.
+    """
     from sublime import windows
     for window in windows():
         for view in window.views():
@@ -95,7 +98,7 @@ def fix_scheme_in_view(view, regenerate=False, ignore_flags=False):
     fix_flag = settings().get("fix_color_schemes", False)
     (fix_syntax, fix_global, fix_custom) = (False, False, False)
     custom_files = []
-    if fix_flag == True:
+    if fix_flag is True:
         (fix_syntax, fix_global) = (True, True)
     elif isinstance(fix_flag, list):
         for label in fix_flag:
@@ -123,12 +126,14 @@ def fix_scheme_in_view(view, regenerate=False, ignore_flags=False):
             # so exit
             return
     else:
-        new_scheme =  "Packages/" + current_directory() + "/" + current_scheme.split("/")[-1].split(".")[0] +\
-                      modified_marker + current_scheme.split(".")[-1]
+        new_scheme = "Packages/" + current_directory() + "/" +\
+            current_scheme.split("/")[-1].split(".")[0] +\
+            modified_marker + current_scheme.split(".")[-1]
 
     if fix_custom:
         for custom_filename in custom_files:
-            if fix_scheme_in_settings(custom_filename, current_scheme, new_scheme):
+            if fix_scheme_in_settings(custom_filename, current_scheme,
+                                      new_scheme):
                 return
     if fix_syntax or ignore_flags:
         syntax_filename = view.settings().get('syntax').split(
@@ -136,14 +141,18 @@ def fix_scheme_in_view(view, regenerate=False, ignore_flags=False):
         if fix_scheme_in_settings(syntax_filename, current_scheme, new_scheme):
             return
     if fix_global or ignore_flags:
-        if fix_scheme_in_settings("Preferences.sublime-settings", current_scheme, new_scheme):
+        if fix_scheme_in_settings("Preferences.sublime-settings",
+                                  current_scheme, new_scheme):
             return
-    print("Could not find or access the settings file where current color_scheme (" +
-          current_scheme + ") is set.")
+    print("Could not find or access the settings file where current"
+          " color_scheme (" + current_scheme + ") is set.")
 
 
-def fix_scheme_in_settings(settings_file, current_scheme, new_scheme, regenerate=False):
-    """Change the color scheme in the given Settings to a background-corrected one"""
+def fix_scheme_in_settings(settings_file, current_scheme, new_scheme,
+                           regenerate=False):
+    """
+    Change the color scheme in the given Settings to a background-corrected one
+    """
     from os.path import join, normpath, isfile
 
     settings = load_settings(settings_file)
@@ -162,12 +171,14 @@ def fix_scheme_in_settings(settings_file, current_scheme, new_scheme, regenerate
 
 
 def generate_scheme_fix(old_scheme, new_scheme_path):
-    """Appends background-correction XML to a color scheme file."""
+    """Append background-correction XML to a color scheme file."""
     from os.path import join
     from re import sub
-    UUID_REGEX = '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
+    UUID_REGEX = '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}' \
+        '-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
 
-    with open(join(packages_path(), current_directory(), 'background_fix.xml')) as f:
+    with open(join(packages_path(), current_directory(),
+                   'background_fix.xml')) as f:
         xml = f.read()
     scheme_data = load_resource(old_scheme)  # only valid for ST3 API!
 

--- a/line.py
+++ b/line.py
@@ -1,179 +1,190 @@
-from os.path import join, dirname, realpath, isfile
+from os.path import join, isfile
 from sublime import HIDDEN, PERSISTENT, load_settings, cache_path
-import subprocess, os, glob, re, platform
+import subprocess
+import os
+import glob
+import re
+import platform
+
 
 class Line:
 
-  # A digit is one-three numbers, with an optional floating point part,
-  # and maybe a % sign, and maybe surrounded by whitespace.
-  DIGIT = '\s*\d{1,3}(\.\d*)?%?\s*'
+    # A digit is one-three numbers, with an optional floating point part,
+    # and maybe a % sign, and maybe surrounded by whitespace.
+    DIGIT = '\s*\d{1,3}(\.\d*)?%?\s*'
 
-  # Three digits is three digits, with commas between.
-  THREE_DIGITS = DIGIT + ',' + DIGIT + ',' + DIGIT
+    # Three digits is three digits, with commas between.
+    THREE_DIGITS = DIGIT + ',' + DIGIT + ',' + DIGIT
 
-  # Four digits is three digits (which we save for later),
-  # and then a comma and then the fourth digit.
-  FOUR_DIGITS = '(' + THREE_DIGITS + '),' + DIGIT
+    # Four digits is three digits (which we save for later),
+    # and then a comma and then the fourth digit.
+    FOUR_DIGITS = '(' + THREE_DIGITS + '),' + DIGIT
 
-  HEX_REGEXP = '#((?:[0-9a-fA-F]{3}){1,2}(?![0-9a-fA-F]+))'
-  RGB_REGEXP = 'rgb\(' + THREE_DIGITS + '\)'
-  RGBA_REGEXP = 'rgba\(' + FOUR_DIGITS + '\)'
-  HSL_REGEXP = 'hsl\(' + THREE_DIGITS + '\)'
-  HSLA_REGEXP = 'hsla\(' + FOUR_DIGITS + '\)'
+    HEX_REGEXP = '#((?:[0-9a-fA-F]{3}){1,2}(?![0-9a-fA-F]+))'
+    RGB_REGEXP = 'rgb\(' + THREE_DIGITS + '\)'
+    RGBA_REGEXP = 'rgba\(' + FOUR_DIGITS + '\)'
+    HSL_REGEXP = 'hsl\(' + THREE_DIGITS + '\)'
+    HSLA_REGEXP = 'hsla\(' + FOUR_DIGITS + '\)'
 
-  def __init__(self, view, region, file_id):
-    self.view     = view
-    self.region   = region
-    self.file_id  = file_id
-    self.settings = load_settings("GutterColor.sublime-settings")
-    self.text     = self.view.substr(self.region)
+    def __init__(self, view, region, file_id):
+        self.view = view
+        self.region = region
+        self.file_id = file_id
+        self.settings = load_settings("GutterColor.sublime-settings")
+        self.text = self.view.substr(self.region)
 
-  def has_color(self):
-    """Returns True/False depending on whether the line has a color in it"""
-    return True if self.color() else False
+    def has_color(self):
+        """Return True/False depending on whether the line has a color in it"""
+        return True if self.color() else False
 
-  def color(self):
-    """Returns the color in the line, if any."""
-    if self.hex_color():
-      return self.hex_color()
-    if self.rgb_color():
-      return self.rgb_color()
-    if self.rgba_color():
-      return self.rgba_color()
-    if self.hsl_color():
-      return self.hsl_color()
-    if self.hsla_color():
-      return self.hsla_color()
-    if not self.settings.get("custom_colors") == None:
-      return self.custom_color()
+    def color(self):
+        """Return the color in the line, if any."""
+        if self.hex_color():
+            return self.hex_color()
+        if self.rgb_color():
+            return self.rgb_color()
+        if self.rgba_color():
+            return self.rgba_color()
+        if self.hsl_color():
+            return self.hsl_color()
+        if self.hsla_color():
+            return self.hsla_color()
+        if not self.settings.get("custom_colors") is None:
+            return self.custom_color()
 
-  def hex_color(self):
-    """Returns the color in the line, if any hex is found."""
-    matches = re.search(Line.HEX_REGEXP, self.text)
-    if matches:
-      return matches.group(0)
+    def hex_color(self):
+        """Return the color in the line, if any hex is found."""
+        matches = re.search(Line.HEX_REGEXP, self.text)
+        if matches:
+            return matches.group(0)
 
-  def rgb_color(self):
-    """Returns the color in the line, if any rgb is found."""
-    matches = re.search(Line.RGB_REGEXP, self.text)
-    if matches:
-      return matches.group(0)
+    def rgb_color(self):
+        """Return the color in the line, if any rgb is found."""
+        matches = re.search(Line.RGB_REGEXP, self.text)
+        if matches:
+            return matches.group(0)
 
-  def rgba_color(self):
-    """Returns the color in the line, if any rgba is found."""
-    matches = re.search(Line.RGBA_REGEXP, self.text)
-    if matches:
-      if self.transparency_settings()[0]:
-        return matches.group(0)
-      else:
-        return 'rgb(' + matches.group(1) + ')'
+    def rgba_color(self):
+        """Return the color in the line, if any rgba is found."""
+        matches = re.search(Line.RGBA_REGEXP, self.text)
+        if matches:
+            if self.transparency_settings()[0]:
+                return matches.group(0)
+            else:
+                return 'rgb(' + matches.group(1) + ')'
 
-  def hsl_color(self):
-    """Returns the color in the line, if any hsl is found."""
-    matches = re.search(Line.HSL_REGEXP, self.text)
-    if matches:
-      return matches.group(0)
+    def hsl_color(self):
+        """Return the color in the line, if any hsl is found."""
+        matches = re.search(Line.HSL_REGEXP, self.text)
+        if matches:
+            return matches.group(0)
 
-  def hsla_color(self):
-    """Returns the color in the line, if any rgba is found."""
-    matches = re.search(Line.HSLA_REGEXP, self.text)
-    if matches:
-      if self.transparency_settings()[0]:
-        return matches.group(0)
-      else:
-        return 'hsl(' + matches.group(1) + ')'
+    def hsla_color(self):
+        """Return the color in the line, if any rgba is found."""
+        matches = re.search(Line.HSLA_REGEXP, self.text)
+        if matches:
+            if self.transparency_settings()[0]:
+                return matches.group(0)
+            else:
+                return 'hsl(' + matches.group(1) + ')'
 
-  def custom_color(self):
-    """Returns the color in the line, if any user-defined is found."""
-    user_colors = self.settings.get("custom_colors")
-    for user_color in user_colors:
-      matches = re.search(user_color["regex"], self.text)
-      group_id = user_color["group_id"] if "group_id" in user_color else 0
-      prefix = user_color["output_prefix"] if "output_prefix" in user_color else ""
-      suffix = user_color["output_suffix"] if "output_suffix" in user_color else ""
-      if matches:
-        return prefix+matches.group(group_id)+suffix
+    def custom_color(self):
+        """Return the color in the line, if any user-defined is found."""
+        user_colors = self.settings.get("custom_colors")
+        for user_color in user_colors:
+            matches = re.search(user_color["regex"], self.text)
+            group_id = user_color[
+                "group_id"] if "group_id" in user_color else 0
+            prefix = user_color[
+                "output_prefix"] if "output_prefix" in user_color else ""
+            suffix = user_color[
+                "output_suffix"] if "output_suffix" in user_color else ""
+            if matches:
+                return prefix + matches.group(group_id) + suffix
 
+    def icon_path(self):
+        """Return the absolute path to the icons."""
+        return join(cache_path(), 'GutterColor', '%s.png' % self.color())
 
-  def icon_path(self):
-    """Returns the absolute path to the icons"""
-    return join(cache_path(), 'GutterColor', '%s.png' % self.color())
+    def relative_icon_path(self):
+        """The relative location of the color icon."""
+        return "Cache/GutterColor/%s.png" % (self.color())
 
-  def relative_icon_path(self):
-    """The relative location of the color icon"""
-    return "Cache/GutterColor/%s.png" % (self.color())
+    def add_region(self):
+        """Add the icon to the gutter."""
+        self.create_icon()
+        self.view.add_regions(
+            "gutter_color_%s" % self.region.a,
+            [self.region],
+            "gutter_color",
+            self.relative_icon_path(),
+            HIDDEN | PERSISTENT
+        )
 
-  def add_region(self):
-    """Add the icon to the gutter"""
-    self.create_icon()
-    self.view.add_regions(
-      "gutter_color_%s" % self.region.a,
-      [self.region],
-      "gutter_color",
-      self.relative_icon_path(),
-      HIDDEN | PERSISTENT
-    )
+    def erase_region(self):
+        """Remove icon from the gutter."""
+        self.view.erase_regions("gutter_color_%s" % self.region.a)
 
-  def erase_region(self):
-    """Remove icon from the gutter"""
-    self.view.erase_regions("gutter_color_%s" % self.region.a)
+    def transparency_settings(self):
+        from .gutter_color import current_directory
+        # transparency settings
+        use_transparency = self.settings.get("use_transparency")
+        if use_transparency is True:
+            background_path = os.path.join(
+                current_directory(True), "transparency_circle_mid.png")
+        elif use_transparency in ("light", "mid"):
+            background_path = os.path.join(current_directory(True), str(
+                "transparency_circle_" + use_transparency + ".png"))
+            print(background_path)
+            use_transparency = True
+        else:
+            use_transparency = False
+        return (use_transparency, background_path)
 
-  def transparency_settings(self):
-    from .gutter_color import current_directory
-    # transparency settings
-    use_transparency = self.settings.get("use_transparency")
-    if use_transparency == True:
-      background_path = os.path.join(current_directory(True),"transparency_circle_mid.png")
-    elif use_transparency in ("light", "mid"):
-      background_path = os.path.join(current_directory(True),str("transparency_circle_"+use_transparency+".png"))
-      print(background_path)
-      use_transparency = True
-    else:
-      use_transparency = False
-    return (use_transparency, background_path)
+    def create_icon(self):
+        paths = [
+            self.settings.get("convert_path"),
+            "/usr/bin/convert",
+            "/usr/local/bin",
+            "/usr/bin"
+        ]
 
-  def create_icon(self):
-    paths = [
-      self.settings.get("convert_path"),
-      "/usr/bin/convert",
-      "/usr/local/bin",
-      "/usr/bin"
-    ]
+        if (platform.system() == "Windows"):
+            delimiter = ";"
+            convert_name = "convert.exe"
+        else:
+            delimiter = ":"
+            convert_name = "convert"
 
-    if ( platform.system()=="Windows"):
-      delimiter = ";"
-      convert_name = "convert.exe"
-    else:
-      delimiter = ":"
-      convert_name = "convert"
+        paths.extend(glob.glob('/usr/local/Cellar/imagemagick/*/bin'))
+        paths.extend(os.environ['PATH'].split(delimiter))
 
-    paths.extend(glob.glob('/usr/local/Cellar/imagemagick/*/bin'))
-    paths.extend(os.environ['PATH'].split(delimiter))
+        convert_path = None
+        WINDOWS_PATH = os.path.join("C:\\Windows\\System32\\convert.exe")
+        for path in paths:
+            if not path.endswith(convert_name):
+                path = os.path.join(path, convert_name)
+            if os.path.isfile(path) and os.access(path, os.X_OK) \
+                    and not os.path.samefile(path, WINDOWS_PATH):
+                convert_path = path
+                break
 
-    convert_path = None
-    for path in paths:
-      if not path.endswith(convert_name):
-        path = os.path.join(path,convert_name)
-      if os.path.isfile(path) and os.access(path, os.X_OK):
-        convert_path = path
-        break
+        (use_transparency, background_path) = self.transparency_settings()
 
-    (use_transparency, background_path) = self.transparency_settings()
-
-    """Create the color icon using ImageMagick convert"""
-    if not use_transparency:
-      script = "\"%s\" -units PixelsPerCentimeter -type TrueColorMatte -channel RGBA " \
-        "-size 32x32 -alpha transparent xc:none " \
-        "-fill \"%s\" -draw \"circle 15,16 8,10\" png32:\"%s\"" % \
-        (convert_path, self.color(), self.icon_path())
-    else:
-      script = "\"%s\" \"%s\" -type TrueColorMatte -channel RGBA " \
-        "-fill \"%s\" -draw \"circle 15,16 8,10\" png32:\"%s\"" % \
-        (convert_path, background_path, self.color(), self.icon_path())
-    if not isfile(self.icon_path()):
-        pr = subprocess.Popen(script,
-          shell = True,
-          stdout = subprocess.PIPE,
-          stderr = subprocess.PIPE,
-          stdin = subprocess.PIPE)
-        (result, error) = pr.communicate()
+        """Create the color icon using ImageMagick convert"""
+        if not use_transparency:
+            script = "\"%s\" -units PixelsPerCentimeter -type TrueColorMatte -channel RGBA " \
+                "-size 32x32 -alpha transparent xc:none " \
+                "-fill \"%s\" -draw \"circle 15,16 8,10\" png32:\"%s\"" % \
+                (convert_path, self.color(), self.icon_path())
+        else:
+            script = "\"%s\" \"%s\" -type TrueColorMatte -channel RGBA " \
+                "-fill \"%s\" -draw \"circle 15,16 8,10\" png32:\"%s\"" % \
+                (convert_path, background_path, self.color(), self.icon_path())
+        if not isfile(self.icon_path()):
+            pr = subprocess.Popen(script,
+                                  shell=True,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE,
+                                  stdin=subprocess.PIPE)
+            (result, error) = pr.communicate()

--- a/line.py
+++ b/line.py
@@ -113,6 +113,9 @@ class Line:
     def add_region(self):
         """Add the icon to the gutter."""
         self.create_icon()
+        # a lot of resource file not found error log
+        if not isfile(self.icon_path()):
+            return
         self.view.add_regions(
             "gutter_color_%s" % self.region.a,
             [self.region],


### PR DESCRIPTION
Windows has a builtin convert.exe  in `"C:\\Windows\\System32\\convert.exe"`. It's a util to convert disk from FAT32 to NTFS etc. We should avoid to call it.

PEP8 linter