### PR TITLE
Add `textual_colors` setting, to toggle rendering color names

### DIFF
--- a/GutterColor.sublime-settings
+++ b/GutterColor.sublime-settings
@@ -16,7 +16,7 @@
      * colors onto a gray checkered background, and "light" is
      * the same as true, but with a brighter BG texture
      */
-     "use_transparency": true,
+    "use_transparency": true,
 
     /*
      * Whether Gutter Color should automatically create a new version of the active
@@ -28,6 +28,12 @@
      * "fix_color_schemes": true is eqivalent to ["global", "syntax-specific"]
      */
     "fix_color_schemes": false,
+
+    /*
+     * Whether Gutter Color should search for and render colors for color names,
+     * e.g. for use with CSS3 color names.
+     */
+    "textual_colors": true,
 
     /*
      * Additional user-defined color matches.

--- a/line.py
+++ b/line.py
@@ -186,7 +186,8 @@ class Line:
 
   def color(self):
     """Returns the color in the line, if any."""
-    if self.web_color():
+    textual_colors = self.settings.get("textual_colors")
+    if textual_colors and self.web_color():
       return self.web_color()
     if self.hex_color():
       return self.hex_color()

--- a/line.py
+++ b/line.py
@@ -187,8 +187,6 @@ class Line:
   def color(self):
     """Returns the color in the line, if any."""
     textual_colors = self.settings.get("textual_colors")
-    if textual_colors and self.web_color():
-      return self.web_color()
     if self.hex_color():
       return self.hex_color()
     if self.rgb_color():
@@ -199,6 +197,8 @@ class Line:
       return self.hsl_color()
     if self.hsla_color():
       return self.hsla_color()
+    if textual_colors and self.web_color():
+      return self.web_color()
     if not self.settings.get("custom_colors") == None:
       return self.custom_color()
 


### PR DESCRIPTION
Additionally, move the check for textual colors ("red", "lime", etc.) after the check for hex, rgb, etc. colors.

Fixes both points raised by https://github.com/ggordan/GutterColor/issues/96