### PR TITLE
Fixes issue #93 [Lots of random "red dots" showing up in the gutter]

### DIFF
--- a/line.py
+++ b/line.py
@@ -205,7 +205,7 @@ class Line:
   def generate_webcolors(self):
     """Generates a list of web color names."""
     self.WEB_COLORS = dict((name, color) for (name, color) in css3_names_to_hex.items())
-    self.WEB_COLORS_REGEX = '((?<!\$)'+ '|(?<!\$)'.join(self.WEB_COLORS.keys()) +')'
+    self.WEB_COLORS_REGEX = '[\\s:](' + '|'.join(self.WEB_COLORS.keys()) + ')[\\s;]'
 
   def web_color(self):
     """Returns the color in the line, if any CSS color name is found."""

--- a/line.py
+++ b/line.py
@@ -211,7 +211,7 @@ class Line:
     """Returns the color in the line, if any CSS color name is found."""
     matches = re.search(self.WEB_COLORS_REGEX, self.text)
     if matches:
-      return matches.group(0)
+      return matches.group(1)
 
   def hex_color(self):
     """Returns the color in the line, if any hex is found."""


### PR DESCRIPTION
This is fixing issue #93 with the regex detecting CSS named colors. I don't understand what the negative lookbehind in the original regex was meant to do.
I'm not sure this regex covers all cases where named colors are used, but I believe it covers the most common.
