### PR TITLE
Added a "convert_name" parameter to allow user customize which binary path of ImageMagick to use

### DIFF
--- a/GutterColor.sublime-settings
+++ b/GutterColor.sublime-settings
@@ -4,6 +4,16 @@
      * The location of the ImageMagic convert script.
      */
     "convert_path" : "/usr/bin/convert",
+    
+    /*
+     * The name of the ImageMagic convert binary file.
+     */
+    /*
+    // Default for Unix system
+    "convert_name" : "convert",
+    // Default for Windows system
+    "convert_name" : "convert.exe",
+    */
 
     /*
      * The syntax for which to run GutterColor.

--- a/line.py
+++ b/line.py
@@ -305,12 +305,17 @@ class Line:
       "/usr/bin"
     ]
 
+    convert_name_setting = self.settings.get("convert_name")
+
     if ( platform.system()=="Windows"):
       delimiter = ";"
       convert_name = "convert.exe"
     else:
       delimiter = ":"
       convert_name = "convert"
+
+    if convert_name_setting:
+      convert_name = convert_name_setting
 
     paths.extend(glob.glob('/usr/local/Cellar/imagemagick/*/bin'))
     paths.extend(os.environ['PATH'].split(delimiter))


### PR DESCRIPTION
Hello,

I had an issue with the last version of ImageMagick (7.0.2 Q16) on Windows, which doesn't provide a convert binary but a "magick" binary with "convert" parameter.
So maybe a customization of this binary name would be helpful with that, as in my proposal.
I left default things in place.

What do you think ?

Thanks. Regards
